### PR TITLE
add function for format filters in controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,11 @@ There are a few options to customize the exports.
   Returns `{ [Object] }`. Default `items`.
   Format Items before making the file.
 
+* `formatFilters(filters)`.
+
+  Returns `{ Object }`. Default `filters`.
+  Customize filters to get records from database
+
 #### File Fields / Headers
 By Default, Every field in the items getted will be include in the files as headers of each column.
 

--- a/lib/controller-export.js
+++ b/lib/controller-export.js
@@ -30,6 +30,10 @@ class ControllerExport {
 		return 86400;
 	}
 
+	formatFilters(filters) {
+		return filters;
+	}
+
 	async generateAndUploadFiles(exportDocument) {
 
 		this.init(exportDocument);
@@ -98,7 +102,7 @@ class ControllerExport {
 	async getItemsByPage(page) {
 
 		const items = await this.model.get({
-			filters: this.filters,
+			filters: !!this.filters && this.formatFilters(this.filters),
 			order: {
 				[this.sortBy]: this.sortDirection
 			},

--- a/tests/created-listener.js
+++ b/tests/created-listener.js
@@ -32,7 +32,7 @@ describe('Created Export Listener', async () => {
 	const exportDocument = {
 		id: validEvent.id,
 		entity: 'cat',
-		filters: { legs: 4 },
+		filters: { legs: 4, isOld: 1 },
 		sortBy: 'bornYear',
 		sortDirection: 'desc',
 		userCreated: 'terrier-1',
@@ -44,7 +44,8 @@ describe('Created Export Listener', async () => {
 			id: index,
 			legs: 4,
 			bornYear: 2019,
-			eyes: 2
+			eyes: 2,
+			isOld: true
 		}));
 
 	const fakeModelPath = path.join(process.cwd(), process.env.MS_PATH || '', 'models', 'cat');
@@ -62,6 +63,19 @@ describe('Created Export Listener', async () => {
 
 			get fileLimit() {
 				return 2;
+			}
+
+			formatFilters(filters) {
+				const forceBoolean = value => !(value === 'false' || value === '0' || !value);
+
+				if(filters.isOld) {
+					return {
+						...filters,
+						isOld: forceBoolean(filters.isOld)
+					};
+				}
+
+				return filters;
 			}
 		}
 
@@ -169,7 +183,7 @@ describe('Created Export Listener', async () => {
 					});
 
 					sandbox.assert.calledOnceWithExactly(FakeModel.prototype.get, {
-						filters: { legs: 4 },
+						filters: { legs: 4, isOld: true },
 						order: {
 							bornYear: 'desc'
 						},
@@ -400,7 +414,7 @@ describe('Created Export Listener', async () => {
 					sandbox.assert.callCount(FakeController.prototype.formatByPage, 5);
 					sandbox.assert.calledThrice(FakeController.prototype.formatByFile);
 					assert(excludeFieldsSpy.get.called);
-					assert(getExcelHeadersSpy.returned(['legs', 'bornYear', 'eyes']));
+					assert(getExcelHeadersSpy.returned(['legs', 'bornYear', 'eyes', 'isOld']));
 					sandbox.assert.calledThrice(ExcelJS.Workbook.prototype.xlsx.writeBuffer);
 					sandbox.assert.calledThrice(S3.putObject);
 					sandbox.assert.calledOnce(ModelExport.prototype.save);


### PR DESCRIPTION
**DESCRIPCIÓN DEL REQUERIMIENTO**

Se debe poder configurar mediante un metodo en `controller-export.js`, que pueda customizar los filtros con que se realizara la busqueda en mongo de los registros.

**DESCRIPCIÓN DE LA SOLUCIÓN**

Se agrego una función llama `formatFilters` en `controller-export.js` para customizar filtrros.Se modificaron los tests.